### PR TITLE
Update autofill to 0.6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "sha12343141234124123112",
-          "version": "5.0.1"
+          "revision": "7b95c4f6b03f008d2ca0882502f2e75887150901",
+          "version": "0.6.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "BrowserServicesKit", targets: ["BrowserServicesKit"])
     ],
     dependencies: [
-        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("5.0.1")),
+        .package(name: "Autofill", url: "https://github.com/duckduckgo/duckduckgo-autofill.git", .exact("0.6.1")),
         .package(name: "GRDB", url: "https://github.com/duckduckgo/GRDB.swift.git", .exact("1.1.0")),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit", .exact("1.1.1")),
         .package(name: "Punycode", url: "https://github.com/gumob/PunycodeSwift.git", .exact("2.1.0")),


### PR DESCRIPTION
**Reviewer:**
**Asana:** https://bskurl.com
**Autofill Release:** https://github.com/GioSensation/test-repository/releases/tag/0.6.1


## Description
Updates Autofill to version [0.6.1](https://github.com/GioSensation/test-repository/releases/tag/0.6.1).

### Autofill 0.6.1 release notes
Test

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).